### PR TITLE
Enable MP4 conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # webm2mp4 Telegram bot
 
-[This bot](https://t.me/webm2mp4bot) converts .webm and .webp links/files to .mp4 videos and .jpg images respectively via ffpmeg.
+[This bot](https://t.me/webm2mp4bot) converts .webm and .webp links/files to .mp4 videos and .jpg images respectively via ffmpeg.
 
 ## Installation
 


### PR DESCRIPTION
Because, telegram still does not implement AV1 support, we can allow mp4 conversion.